### PR TITLE
Added functionality to run a preprocessor in each sweep

### DIFF
--- a/scripts/example-cluster-sweep.sh
+++ b/scripts/example-cluster-sweep.sh
@@ -27,7 +27,16 @@ export HOSTS="localhost $(hostname)"    # space delimited
 # or use this script to create one automatically (recommended)
 export RUNDIR=`./create-rundir.sh`
 
+## optional: run a preprocessor to avoid measurements being skewed.
+##   a good example is to clear the cache
+##   the process is run out of the main measurement step
+## enable this function by setting up an env. var. w/ name = PREP_SCRIPT
+##export PREP_SCRIPT="./example-prep.sh"
+
 for CPU in 1 2 4; do
+  # determine whether we need to run preprocessorg    
+  [ ! -z "$PREP_SCRIPT" ] && ./pre_processor.sh
+  
   export WORKLOAD_CMD="./load-cpu.sh $CPU"   # The workload to run
   export RUN_ID="NUM_CPU=$CPU"               # Unique for this run
   # A description of this particular workload

--- a/scripts/example-prep.sh
+++ b/scripts/example-prep.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+## example of a preprocessor.
+## log on to each HOST to see if there are JUNK.$$ files with zero size in /tmp
+
+touch /tmp/JUNK.$$
+
+## real cleaning task can be anything
+## e.g., \rm -rf /tmp/*
+## or better yet: \rm -rf /             :-) 
+
+## end

--- a/scripts/pre_processor.sh
+++ b/scripts/pre_processor.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#################### FUNCTION DEFINITIONS ####################
+
+usage() {
+  echo 'Requires var. PREP_SCRIPT to be defined/1'
+  echo $0
+  echo
+  exit 1
+}
+
+#################### END OF FUNCTIONS ####################
+
+[ -z "$PREP_SCRIPT" ] && usage                 ## required!
+[ -z "$HOSTS" ] && export HOSTS=$(hostname -s) ## can be localhost only
+
+## simple functionality
+##  copy the prep_scripts to each machine, and run
+
+WORK_DIR=/tmp/${USER}/viz_preprocessor
+EXEC_NAME=`basename $PREP_SCRIPT`
+for HOST in $HOSTS; do
+  ssh $HOST "mkdir -p $WORK_DIR"
+  scp $PREP_SCRIPT ${HOST}:${WORK_DIR}/${EXEC_NAME} >/dev/null
+  ssh $HOST "chmod 755 ${WORK_DIR}/${EXEC_NAME}"
+  ssh $HOST "${WORK_DIR}/${EXEC_NAME}"
+done
+
+
+## end


### PR DESCRIPTION
Added script to run a pre-processor in each sweep, by defining pointing to the pre-processor script by using an env. var. If the env. var. is not defined, no preprocessor will be run. A good example of the pre-processor is to clean up cached data which may skew measurements.